### PR TITLE
Improvement proposal to speedup file search

### DIFF
--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -3513,6 +3513,7 @@ function [sFoundStudy, iFoundStudy, iItem] = findFileInStudies(fieldGroup, field
     sFoundStudy = [];
     iFoundStudy = [];
     iItem       = [];
+    fieldFolder = fileparts(fieldFile);
     % Get protocol information
     ProtocolStudies = GlobalData.DataBase.ProtocolStudies(GlobalData.DataBase.iProtocol);
     % List studies to process
@@ -3530,6 +3531,10 @@ function [sFoundStudy, iFoundStudy, iItem] = findFileInStudies(fieldGroup, field
         end
         % Check if field is available for the study
         if isempty(sStudy.(fieldGroup))
+            continue;
+        end
+        % Check we are in the correct folder
+        if ~file_compare(fieldFolder, fileparts(sStudy.FileName))
             continue;
         end
         % Get list of files from study


### PR DESCRIPTION
Make use of the folder part of the FileName field to avoid going through individual files of each study. I tested with a big protocol: this resulted in 15x less calls to file_compare() which was biggest bottleneck, resulting in a 7.5x speedup. In a protocol requiring currently hundreds of thousands of file_compares, this could be a huge improvement. In my tests, nothing seemed to break but maybe it is not 100% reliable to rely on the FileName field having the parent folder? Please advise.