### PR TITLE
Refactor set channel flag actions as process 

### DIFF
--- a/toolbox/process/functions/process_channel_setbad.m
+++ b/toolbox/process/functions/process_channel_setbad.m
@@ -59,22 +59,10 @@ end
 
 %% ===== RUN =====
 function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
-    OutputFiles = {};
-    % Get options
-    BadList = sProcess.options.sensortypes.Value;
-    isInteractive = sProcess.options.isInteractive.Value;
-    if isempty(BadList) && ~isInteractive
-        bst_report('Error', sProcess, [], 'Empty list of bad channels.');
-        return
-    end
-    % Add bad channels
-    if isInteractive && isempty(BadList)
-        tree_set_channelflag({sInputs.FileName}, 'AddBad');
-    else
-        tree_set_channelflag({sInputs.FileName}, 'AddBad', BadList);
-    end
-    % Return all the files in input
-    OutputFiles = {sInputs.FileName};
+    % Set flagmode to: 'Mark some channels as bad...' 
+    sProcess.options.flagmode.Value = 1;
+    % Call TIME-FREQ process
+    OutputFiles = process_tree_channelflag('Run', sProcess, sInputs);
 end
 
 

--- a/toolbox/process/functions/process_tree_channelflag.m
+++ b/toolbox/process/functions/process_tree_channelflag.m
@@ -1,0 +1,101 @@
+function varargout = process_tree_channelflag( varargin )
+% PROCESS_TREE_CHANNELFLAG: Process wrapper of tree_set_channelflag().
+
+% @=============================================================================
+% This function is part of the Brainstorm software:
+% https://neuroimage.usc.edu/brainstorm
+% 
+% Copyright (c)2000-2020 University of Southern California & McGill University
+% This software is distributed under the terms of the GNU General Public License
+% as published by the Free Software Foundation. Further details on the GPLv3
+% license can be found at http://www.gnu.org/copyleft/gpl.html.
+% 
+% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+%
+% For more information type "brainstorm license" at command prompt.
+% =============================================================================@
+%
+% Authors: Raymundo Cassani, 2021
+
+eval(macro_method);
+end
+
+
+%% ===== GET DESCRIPTION =====
+function sProcess = GetDescription() %#ok<DEFNU>
+    % Description the process
+    sProcess.Comment     = 'Set good / bad channels';
+    sProcess.Category    = 'Custom';
+    sProcess.SubGroup    = {'Import', 'Channel file'};
+    sProcess.Index       = 81;
+    sProcess.Description = 'https://neuroimage.usc.edu/brainstorm/Tutorials/BadChannels';
+    % Definition of the input accepted by this process
+    sProcess.InputTypes  = {'data', 'raw'};
+    sProcess.OutputTypes = {'data', 'raw'};
+    sProcess.nInputs     = 1;
+    sProcess.nMinFiles   = 1;
+    % Option: Value
+    sProcess.options.flagmode.Comment = {'Mark some channels as bad...', ...
+                                         'Mark some channels as good...', ...
+                                         'Mark flat channels as bad', ...
+                                         'Mark all channels as good'};
+    sProcess.options.flagmode.Type    =  'radio';
+    sProcess.options.flagmode.Value   =  1;
+    % === Sensor types
+    sProcess.options.sensortypes.Comment = 'Channel types or names: ';
+    sProcess.options.sensortypes.Type    = 'text';
+    sProcess.options.sensortypes.Value   = '';
+    sProcess.options.sensortypes.InputTypes = {'data', 'raw'};
+    % === Whether process is run interactively
+    sProcess.options.isInteractive.Comment = 'Is interactive?';
+    sProcess.options.isInteractive.Type    = 'checkbox';
+    sProcess.options.isInteractive.Value   = 0;
+    sProcess.options.isInteractive.Hidden  = 1;
+end
+
+
+%% ===== FORMAT COMMENT =====
+function Comment = FormatComment(sProcess) %#ok<DEFNU>
+    Comment = sProcess.Comment;
+end
+
+
+%% ===== RUN =====
+function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
+    OutputFiles = {};
+    % Get options
+    switch sProcess.options.flagmode.Value
+        case 1, Flagmode = 'AddBad';
+        case 2, Flagmode = 'ClearBad';
+        case 3, Flagmode = 'DetectFlat';
+        case 4, Flagmode = 'ClearAllBad';           
+    end   
+    ChannelList = sProcess.options.sensortypes.Value;
+    isInteractive = sProcess.options.isInteractive.Value;
+    
+    switch Flagmode
+        case {'AddBad', 'ClearBad'}
+            if isempty(ChannelList)
+                if isInteractive
+                    tree_set_channelflag({sInputs.FileName}, Flagmode);
+                else
+                    bst_report('Error', sProcess, [], 'Empty list of channels.');
+                    return
+                end
+            else
+                tree_set_channelflag({sInputs.FileName}, Flagmode, ChannelList);    
+            end   
+        
+        case {'DetectFlat', 'ClearAllBad'} 
+            tree_set_channelflag({sInputs.FileName}, Flagmode);
+    end 
+    % Return all the files in input
+    OutputFiles = {sInputs.FileName};
+end
+
+
+

--- a/toolbox/process/functions/process_tree_channelflag.m
+++ b/toolbox/process/functions/process_tree_channelflag.m
@@ -90,12 +90,16 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
                 tree_set_channelflag({sInputs.FileName}, Flagmode, ChannelList);    
             end   
         
-        case {'DetectFlat', 'ClearAllBad'} 
+        case {'DetectFlat'}           
             tree_set_channelflag({sInputs.FileName}, Flagmode);
+            
+        case {'ClearAllBad'}
+            if isInteractive
+                tree_set_channelflag({sInputs.FileName}, Flagmode);
+            else
+                tree_set_channelflag({sInputs.FileName}, [Flagmode,'NoWarning']);
+            end
     end 
     % Return all the files in input
     OutputFiles = {sInputs.FileName};
 end
-
-
-

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -2519,11 +2519,14 @@ end % END SWITCH( ACTION )
         end
         
         jMenu = gui_component('Menu', jPopup, [], 'Good/bad channels', IconLoader.ICON_GOODBAD, [], []);
-        gui_component('MenuItem', jMenu, [], 'Mark some channels as good...', IconLoader.ICON_GOOD, [], @(h,ev)tree_set_channelflag(bstNodes, 'ClearBad'));
-        gui_component('MenuItem', jMenu, [], 'Mark all channels as good',     IconLoader.ICON_GOOD, [], @(h,ev)tree_set_channelflag(bstNodes, 'ClearAllBad'));
+        gui_component('MenuItem', jMenu, [], 'Mark some channels as good...', IconLoader.ICON_GOOD, [], ...
+            @(h,ev)bst_process('CallProcess', 'process_tree_channelflag', DataFiles, [], 'sensortypes', [], 'isInteractive', 1, 'flagmode', 2));
+        gui_component('MenuItem', jMenu, [], 'Mark all channels as good',     IconLoader.ICON_GOOD, [], ...
+            @(h,ev)bst_process('CallProcess', 'process_tree_channelflag', DataFiles, [], 'sensortypes', [], 'isInteractive', 1, 'flagmode', 4));
         gui_component('MenuItem', jMenu, [], 'Mark some channels as bad...',  IconLoader.ICON_BAD,  [], ...
-            @(h,ev)bst_process('CallProcess', 'process_channel_setbad', DataFiles, [], 'sensortypes', [], 'isInteractive', 1));
-        gui_component('MenuItem', jMenu, [], 'Mark flat channels as bad',     IconLoader.ICON_BAD,  [], @(h,ev)tree_set_channelflag(bstNodes, 'DetectFlat'));
+            @(h,ev)bst_process('CallProcess', 'process_tree_channelflag', DataFiles, [], 'sensortypes', [], 'isInteractive', 1, 'flagmode', 1));
+        gui_component('MenuItem', jMenu, [], 'Mark flat channels as bad',     IconLoader.ICON_BAD,  [], ...
+            @(h,ev)bst_process('CallProcess', 'process_tree_channelflag', DataFiles, [], 'sensortypes', [], 'isInteractive', 1, 'flagmode', 3));
         gui_component('MenuItem', jMenu, [], 'View all bad channels',         IconLoader.ICON_BAD,  [], @(h,ev)tree_set_channelflag(bstNodes, 'ShowBad'));
     end
 %% ===== MENU: HEADMODEL =====

--- a/toolbox/tree/tree_set_channelflag.m
+++ b/toolbox/tree/tree_set_channelflag.m
@@ -5,6 +5,7 @@ function tree_set_channelflag(bstNodes, action, strChan)
 %         tree_set_channelflag(bstNodes, 'DetectFlat')  : Detect bad channels (values are all zeros)
 %         tree_set_channelflag(bstNodes, 'ClearBad')    : Set some the channels as good for all the data files
 %         tree_set_channelflag(bstNodes, 'ClearAllBad') : Set all the channels as good for all the data files
+%         tree_set_channelflag(bstNodes, 'ClearAllBadNoWarning') : Same as 'ClearAllBad', but Warning is not shown 
 %         tree_set_channelflag(bstNodes, 'ShowBad')     : Display all the bad channels (as text)
 %         tree_set_channelflag(DataFiles, action, strChan) : Pass the filenames and list of channels in argument (no gui)
 
@@ -264,7 +265,7 @@ for i = 1:length(iStudies)
             % Save file
             bst_save(DataFileFull, DataMat, 'v6', 1);
             
-        case 'clearallbad'
+        case {'clearallbad', 'clearallbadnowarning'}
             if (i == 1)
                 strReportTitle = 'Cleared bad channels (Subject/Condition/File):';
             end


### PR DESCRIPTION
1. Created `process_tree_channelflag` to wrap the options of `tree_set_channelflag`
2. Updated the tree callbacks
3. Updated `process_channel_setbad` to call `process_tree_channelflag` (`process_channel_setbad`  can be hidden from the Pipeline editor)
4. `tree_set_channelflag` prompts a warning for the user for the option "Mark all channels as good".  This warning is avoided when the process is not interactive